### PR TITLE
Updated addressPoints to load from https

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -26,7 +26,7 @@
 
 <script src="../dist/leaflet-heat.js"></script>
 
-<script src="http://leaflet.github.io/Leaflet.markercluster/example/realworld.10000.js"></script>
+<script src="https://leaflet.github.io/Leaflet.markercluster/example/realworld.10000.js"></script>
 <script>
 
 var map = L.map('map').setView([-37.87, 175.475], 12);


### PR DESCRIPTION
The demo doesn't work in Google Chrome (Version 33.0.1750.149) or Mozilla Firefox (Version 28.0) due to insecure content being loaded using http. Changing the addressPoints to be loaded from https fixes the issue in both Google Chrome and Firefox. The same issue is present in the Safari (Version 7.0.3) browser but the map is being displayed.
