### PR TITLE
fixed problem with override canvas other canvas

### DIFF
--- a/src/HeatLayer.js
+++ b/src/HeatLayer.js
@@ -50,7 +50,7 @@ L.HeatLayer = L.Class.extend({
             this._initCanvas();
         }
 
-        map._panes.overlayPane.appendChild(this._canvas);
+        map._panes.overlayPane.appendChild(this._div);
 
         map.on('moveend', this._reset, this);
 
@@ -62,7 +62,7 @@ L.HeatLayer = L.Class.extend({
     },
 
     onRemove: function (map) {
-        map.getPanes().overlayPane.removeChild(this._canvas);
+        map.getPanes().overlayPane.removeChild(this._div);
 
         map.off('moveend', this._reset, this);
 
@@ -77,7 +77,9 @@ L.HeatLayer = L.Class.extend({
     },
 
     _initCanvas: function () {
+        this._div = L.DomUtil.create('div', 'leaflet-layer');
         var canvas = this._canvas = L.DomUtil.create('canvas', 'leaflet-heatmap-layer leaflet-layer');
+        this._div.appendChild(canvas);
 
         var size = this._map.getSize();
         canvas.width  = size.x;


### PR DESCRIPTION
fixed problem with override canvas other canvas,
if use the heatlayer more than one time on a map.

А теперь на русском.
В общем, браузеры не умеют рисовать одну канву над другой если они в одном `div`

``` html
<div class="leaflet-overlay-pane">
    <canvas class="leaflet-heatmap-layer leaflet-layer leaflet-zoom-animated">
    <!-- второй -->
    <canvas class="leaflet-heatmap-layer leaflet-layer leaflet-zoom-animated">
</div>
```

Так вот если я допустим хочу создать два heatlayer для отображения различной активности.
То браузер перестает рисовать второй холст не будет виден, в частности в Chrome.
Чтоб это решить надо каждую `canvas` обернуть в `div`
То есть:

``` html
<div class="leaflet-overlay-pane">
    <div class="leaflet-layer">
        <canvas class="leaflet-heatmap-layer leaflet-layer leaflet-zoom-animated">
    </div>
    <!-- второй -->
    <div class="leaflet-layer">
        <canvas class="leaflet-heatmap-layer leaflet-layer leaflet-zoom-animated">
    </div>
</div>
```
