### PR TITLE
Alpha blend coincident data points

### DIFF
--- a/src/HeatLayer.js
+++ b/src/HeatLayer.js
@@ -128,7 +128,7 @@ L.HeatLayer = (L.Layer ? L.Layer : L.Class).extend({
 
             max = this.options.max === undefined ? 1 : this.options.max,
             maxZoom = this.options.maxZoom === undefined ? this._map.getMaxZoom() : this.options.maxZoom,
-            v = 1 / Math.pow(2, Math.max(0, Math.min(maxZoom - this._map.getZoom(), 12))),
+            v = 1, // vestigial
             cellSize = r / 2,
             grid = [],
             panePos = this._map._getMapPanePos(),
@@ -157,7 +157,8 @@ L.HeatLayer = (L.Layer ? L.Layer : L.Class).extend({
                 } else {
                     cell[0] = (cell[0] * cell[2] + p.x * k) / (cell[2] + k); // x
                     cell[1] = (cell[1] * cell[2] + p.y * k) / (cell[2] + k); // y
-                    cell[2] += k; // cumulated intensity value
+                    // Join multiple cell values using alpha blending
+                    cell[2] = (cell[2] * (1 - k/max)) + k;
                 }
             }
         }


### PR DESCRIPTION
The grid mechanism basically combines data points that are closer than `cellSize` into a single data point. It was doing this by adding together the altitudes. If the grid is intended to be a higher-performance approximation of sending all of the individual data points to simpleheat, then this isn't the correct way to combine altitudes. In simpleheat, two points drawn on top of each other with altitude of `max * 0.5` would not look like a single point of altitude `max`, but rather `max * 0.75`, because they are combined using alpha blending. (The blurred part of the circle will always look a bit different--I don't know how you can fix that with the grid approach.)

By using alpha blending, we can get rid of the `v` parameter, which (correct me if I'm wrong) was an attempt to prevent clustered points from always adding up to max intensity. Alpha blending solves this problem more directly.

Getting rid of the `v` parameter means that adding a single point of altitude = `max` will appear with the maximum intensity of color, which is what you get with simpleheat and what users would expect. It also means that two max altitude points on top of each other will look the same (at least in the center) as one max altitude point, which is again a more correct/expected result.
