### PR TITLE
Do not redraw if layer is not more on the map:

### DIFF
--- a/src/HeatLayer.js
+++ b/src/HeatLayer.js
@@ -118,6 +118,9 @@ L.HeatLayer = (L.Layer ? L.Layer : L.Class).extend({
     },
 
     _redraw: function () {
+        if (!this._map) {
+            return;
+        }
         var data = [],
             r = this._heat._r,
             size = this._map.getSize(),


### PR DESCRIPTION
If we ask for a `redraw` then quickly remove the layer from the map,
_redraw will fail because it's called through requestAnimFrame, and thus
async.

See http://playground-leaflet.rhcloud.com/sas/edit?html,output
