### PR TITLE
Changes for bubble heatmap rendenering

### DIFF
--- a/src/HeatLayer.js
+++ b/src/HeatLayer.js
@@ -87,6 +87,7 @@ L.HeatLayer = (L.Layer ? L.Layer : L.Class).extend({
         L.DomUtil.addClass(canvas, 'leaflet-zoom-' + (animated ? 'animated' : 'hide'));
 
         this._heat = simpleheat(canvas);
+	this._heat.fixedOpacity(100);
         this._updateOptions();
     },
 

--- a/src/HeatLayer.js
+++ b/src/HeatLayer.js
@@ -145,7 +145,7 @@ L.HeatLayer = (L.Layer ? L.Layer : L.Class).extend({
                 var alt =
                     this._latlngs[i].alt !== undefined ? this._latlngs[i].alt :
                     this._latlngs[i][2] !== undefined ? +this._latlngs[i][2] : 1;
-                k = alt * v;
+                k = alt; 
 
                 grid[y] = grid[y] || [];
                 cell = grid[y][x];


### PR DESCRIPTION
I don't fully understand how the values are combined, but the change at line 149 works better for my heatmaps.  Someone that understands the other use cases will likely have a better solution.

Optionally rendering all colors with the same transparency results in better heatmaps. 

![jstorheatmapalpha](https://cloud.githubusercontent.com/assets/957677/15159543/2664ad10-16c3-11e6-9e49-ebb967a04312.png)
