### PR TITLE
Fix k value generation that could lead to NaN

### DIFF
--- a/src/HeatLayer.js
+++ b/src/HeatLayer.js
@@ -155,8 +155,11 @@ L.HeatLayer = (L.Layer ? L.Layer : L.Class).extend({
 
                 var alt =
                     this._latlngs[i].alt !== undefined ? this._latlngs[i].alt :
-                    this._latlngs[i][2] !== undefined ? +this._latlngs[i][2] : 1;
-                k = alt * v;
+                    this._latlngs[i][2] !== undefined ? +this._latlngs[i][2] : 0;
+                if (isNaN(alt) || alt == 0) {
+                	alt = 1;
+                }
+                k = Math.abs(alt) * v;
 
                 grid[y] = grid[y] || [];
                 cell = grid[y][x];


### PR DESCRIPTION
In redraw, if alt == 0 or NaN, it could lead to a k value = 0, which in some edge cases would cause cell[0] and cell[1] to be NaN and for data to not be displayed on the map.
