### PR TITLE
add possibility to use options latField, lngField, and valueField

### DIFF
--- a/src/HeatLayer.js
+++ b/src/HeatLayer.js
@@ -148,14 +148,29 @@ L.HeatLayer = (L.Layer ? L.Layer : L.Class).extend({
 
         // console.time('process');
         for (i = 0, len = this._latlngs.length; i < len; i++) {
-            p = this._map.latLngToContainerPoint(this._latlngs[i]);
+
+
+            var point = this._latlngs[i];
+
+            // use options to get lat and lng fields
+            if (this.options.latField !== undefined && this.options.lngField !== undefined) {
+                if (this.options.valueField !== undefined) {
+                   point = new L.LatLng(point[this.options.latField], point[this.options.lngField], point[this.options.valueField]);
+                }
+                else {
+                    point = new L.LatLng(point[this.options.latField], point[this.options.lngField]);
+                }
+            }
+
+
+            p = this._map.latLngToContainerPoint(point);
             if (bounds.contains(p)) {
                 x = Math.floor((p.x - offsetX) / cellSize) + 2;
                 y = Math.floor((p.y - offsetY) / cellSize) + 2;
 
                 var alt =
-                    this._latlngs[i].alt !== undefined ? this._latlngs[i].alt :
-                    this._latlngs[i][2] !== undefined ? +this._latlngs[i][2] : 1;
+                    point.alt !== undefined ? point.alt :
+                    point[2] !== undefined ? +tpoint[2] : 1;
                 k = alt * v;
 
                 grid[y] = grid[y] || [];


### PR DESCRIPTION
This patch adds the possibility to use options latField, lngField, and valueField.

Example : 

```
        $scope.layers.overlays = {
                heat: {
                    name: 'Heat Map',
                    type: 'heat',

                    data: heatPoints,
                    layerOptions: {
                        radius: 20,
                        blur: 10,
                       // which field name in your data represents the latitude - default "lat"
                        latField: 'lat',
                        // which field name in your data represents the longitude - default "lng"
                        lngField: 'lng',
                        // which field name in your data represents the data value - default "value"
                        valueField: 'count'
                    },
                    visible: true
                }
            };    
```
