### PR TITLE
redraw don't crash if this._map doesn't exist

### DIFF
--- a/src/HeatLayer.js
+++ b/src/HeatLayer.js
@@ -34,7 +34,7 @@ L.HeatLayer = (L.Layer ? L.Layer : L.Class).extend({
     },
 
     redraw: function () {
-        if (this._heat && !this._frame && !this._map._animating) {
+        if (this._heat && !this._frame && this._map && !this._map._animating) {
             this._frame = L.Util.requestAnimFrame(this._redraw, this);
         }
         return this;


### PR DESCRIPTION
Where the heatmap is not on the map the code crashed at while testing `!this._map._animating`
