### PR TITLE
Add getLatLng method to HeatLayer.js

### DIFF
--- a/src/HeatLayer.js
+++ b/src/HeatLayer.js
@@ -15,6 +15,10 @@ L.HeatLayer = (L.Layer ? L.Layer : L.Class).extend({
         L.setOptions(this, options);
     },
 
+    getLatLng: function () {
+        return this._latlngs;
+    },
+
     setLatLngs: function (latlngs) {
         this._latlngs = latlngs;
         return this.redraw();


### PR DESCRIPTION
Added `getLatLng` method to support `featureGroup` `getBounds` method. This is useful for fitting the heatmap layer to the map using `map.fitBounds`