### PR TITLE
Fix Demo: Update CDN Links

### DIFF
--- a/demo/draw.html
+++ b/demo/draw.html
@@ -2,8 +2,8 @@
 <html>
 <head>
     <title>Leaflet.heat demo</title>
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
-    <script src="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.8.0/dist/leaflet.css" />
+    <script src="https://cdn.jsdelivr.net/npm/leaflet@1.8.0/dist/leaflet-src.min.js"></script>
     <style>
         #map { width: 800px; height: 600px; }
         body { font: 16px/1.4 "Helvetica Neue", Arial, sans-serif; }

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,8 +2,8 @@
 <html>
 <head>
     <title>Leaflet.heat demo</title>
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
-    <script src="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.8.0/dist/leaflet.css" />
+    <script src="https://cdn.jsdelivr.net/npm/leaflet@1.8.0/dist/leaflet-src.min.js"></script>
     <style>
         #map { width: 800px; height: 600px; }
         body { font: 16px/1.4 "Helvetica Neue", Arial, sans-serif; }


### PR DESCRIPTION
While `Leaflet.heat` seems to work great with the latest leaflet versions, the demo page currently does not render because it tries to include an outdated leaflet version from CDN which is no longer serving it. Hence, the demo shows a blank page. 

This PR updates the CDN urls of script and stylesheet, to return the demo to being fully functional:

![image](https://user-images.githubusercontent.com/7556675/183689797-6090a756-8d11-47ad-a818-6fd987714d1b.png)
